### PR TITLE
add channel options

### DIFF
--- a/tensor_serving_client/min_tfs_client/options.py
+++ b/tensor_serving_client/min_tfs_client/options.py
@@ -1,0 +1,54 @@
+from typing import List, Tuple, Any
+
+from abc import ABC
+
+gRCPOptionsReturnType = List[Tuple[str, Any]]
+
+
+class AbstractgRPCChannelOptions(ABC):
+    """
+    Abstract gRPC channel options abstract class
+
+    This abstract class sets the interface that should be implemented in order to
+    play nicely with gRPC channels option
+    """
+    def __repr__(self) -> gRCPOptionsReturnType:
+        return [
+            (f"grpc.{attr}", value)
+            for attr, value in self.__dict__.items()
+        ]
+
+
+class gRPCChannelOptions(AbstractgRPCChannelOptions):
+    """
+    gRPC channel options DTO class.
+
+    This class allows to pass additional gRPC options to manage channel.
+    Right know it implements only two options:
+        - max send message length
+        - max receive message length
+
+    But it could be easily extended in future as part of the functionality of current package,
+    or implementer by user
+    """
+
+    def __init__(
+            self,
+            max_send_message_length: int = 512,
+            max_receive_message_length: int = 512,
+    ):
+        """
+        Object constructor
+        :arg max_send_message_length: Maximum send message specified in Mb
+        :arg max_send_message_length: Maximum send message specified in Mb
+        """
+        _mb_multiplier = 1024 * 1024
+        self.max_receive_message_length = \
+            max_receive_message_length * _mb_multiplier
+        self.max_send_message_length = \
+            max_send_message_length * _mb_multiplier
+
+
+if __name__ == "__main__":
+    a = gRPCChannelOptions()
+    print(a.__repr__())

--- a/tensor_serving_client/min_tfs_client/requests.py
+++ b/tensor_serving_client/min_tfs_client/requests.py
@@ -14,6 +14,7 @@ from tensorflow_serving.apis.get_model_status_pb2 import (
 from tensorflow_serving.apis.model_service_pb2_grpc import ModelServiceStub
 
 from .tensors import ndarray_to_tensor_proto
+from .options import AbstractgRPCChannelOptions
 
 RequestTypes = Union[PredictRequest, ClassificationRequest, RegressionRequest]
 ResponseTypes = Union[PredictResponse, ClassificationResponse, RegressionResponse]
@@ -21,13 +22,19 @@ ResponseTypes = Union[PredictResponse, ClassificationResponse, RegressionRespons
 
 class TensorServingClient:
     def __init__(
-        self, host: str, port: int, credentials: Optional[grpc.ssl_channel_credentials] = None,
+        self,
+        host: str,
+        port: int,
+        credentials: Optional[grpc.ssl_channel_credentials] = None,
+        options: Optional[AbstractgRPCChannelOptions] = None,
     ) -> None:
         self._host_address = f"{host}:{port}"
+        self._options = repr(options) if options else None
+
         if credentials:
-            self._channel = grpc.secure_channel(self._host_address, credentials)
+            self._channel = grpc.secure_channel(self._host_address, credentials, options=options)
         else:
-            self._channel = grpc.insecure_channel(self._host_address)
+            self._channel = grpc.insecure_channel(self._host_address, options=options)
 
     def _make_inference_request(
         self,


### PR DESCRIPTION
Hi there,
So, recently I've worked on serving my models with tensorflow serving. And I found your package for making gRPC requests that realy exited me and help me to work on my project faster. 
But since my model input are images and outputs are large enought too, they both exceeds receive and sent message limit for channel for gRPC. 
I've manage to achieve desired results but with few tweek on your package side.  Essential, I did this: 
```
class TensorServingClient:
    def __init__(
        self, host: str, port: int, credentials: Optional[grpc.ssl_channel_credentials] = None,
    ) -> None:
        self._host_address = f"{host}:{port}"
        options = [('grpc.max_send_message_length', 512 * 1024 * 1024),
                   ('grpc.max_receive_message_length', 512 * 1024 * 1024)]
        if credentials:
            self._channel = grpc.secure_channel(
                self._host_address, credentials,
                options=options
            )
        else:
            self._channel = grpc.insecure_channel(self._host_address,
                                                  options=options)
```
Which is okay for the first time, but I want to achive more consistent result and help make others to achive them.
So basically I've introduce new object:

```
class gRPCChannelOptions(AbstractgRPCChannelOptions):
    """
    gRPC channel options DTO class.

    This class allows to pass additional gRPC options to manage channel.
    Right know it implements only two options:
        - max send message length
        - max receive message length

    But it could be easily extended in future as part of the functionality of current package,
    or implementer by user
    """

    def __init__(
            self,
            max_send_message_length: int = 512,
            max_receive_message_length: int = 512,
    ):
        """
        Object constructor
        :arg max_send_message_length: Maximum send message specified in Mb
        :arg max_send_message_length: Maximum send message specified in Mb
        """
        _mb_multiplier = 1024 * 1024
        self.max_receive_message_length = \
            max_receive_message_length * _mb_multiplier
        self.max_send_message_length = \
            max_send_message_length * _mb_multiplier
```
To be able to get list of tuples that gRPC consumes to change it internal configuration. But since I'm not familiar with with gPRC internal well I've decided to make both an abstaction and a concrete implementation only for my specific case. But I left a room for new users to be able to be able to fullfill wheir need with simple inheritence from my abstract class.
```
class AbstractgRPCChannelOptions(ABC):
    """
    Abstract gRPC channel options abstract class

    This abstract class sets the interface that should be implemented in order to
    play nicely with gRPC channels option
    """
    def __repr__(self) -> gRCPOptionsReturnType:
        return [
            (f"grpc.{attr}", value)
            for attr, value in self.__dict__.items()
        ]
```
And client class now looks like this:
```
class TensorServingClient:
    def __init__(
        self,
        host: str,
        port: int,
        credentials: Optional[grpc.ssl_channel_credentials] = None,
        options: Optional[AbstractgRPCChannelOptions] = None,
    ) -> None:
        self._host_address = f"{host}:{port}"
        self._options = repr(options) if options else None

        if credentials:
            self._channel = grpc.secure_channel(self._host_address, credentials, options=options)
        else:
            self._channel = grpc.insecure_channel(self._host_address, options=options)
```