### PR TITLE
Adding support for OVMS - Open Vino Model Server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .pytest_cache
 **/__pycache__
 *.egg-info
+.idea
 
 # Python Distro Folders
 build/

--- a/tensor_serving_client/min_tfs_client/tensors.py
+++ b/tensor_serving_client/min_tfs_client/tensors.py
@@ -23,7 +23,7 @@ def write_values_to_tensor_proto(
     else:
         proto_field.extend([coerce_to_bytes(v) for v in values])
     # OVMS is expecting tensor_content to be filled with the bytes, therefore we added this,
-    # after reverse-engineering the tensorflow_serving library.
+    # to be consistent with the way it is handled in the tensorflow_serving library.
     tensor_proto.tensor_content = values.tobytes()
     return tensor_proto
 
@@ -45,7 +45,7 @@ def extract_shape(tensor_proto: TensorProto) -> Tuple[int, ...]:
 def tensor_proto_to_ndarray(tensor_proto: TensorProto) -> np.ndarray:
     dtype = DataType(tensor_proto.dtype)
     shape = extract_shape(tensor_proto)
-    # MIIL extension: this is needed to deal with the format returned by OpenVino inference server.
+    # This is needed to deal with the format returned by OpenVino inference server.
     if tensor_proto.tensor_content:
         return (np.frombuffer(tensor_proto.tensor_content,
                               dtype=dtype.numpy_dtype).copy().reshape(shape))

--- a/tensor_serving_client/min_tfs_client/tensors.py
+++ b/tensor_serving_client/min_tfs_client/tensors.py
@@ -22,6 +22,9 @@ def write_values_to_tensor_proto(
         proto_field.extend([v.item() for v in values])
     else:
         proto_field.extend([coerce_to_bytes(v) for v in values])
+    # OVMS is expecting tensor_content to be filled with the bytes, therefore we added this,
+    # after reverse-engineering the tensorflow_serving library.
+    tensor_proto.tensor_content = values.tobytes()
     return tensor_proto
 
 
@@ -42,5 +45,13 @@ def extract_shape(tensor_proto: TensorProto) -> Tuple[int, ...]:
 def tensor_proto_to_ndarray(tensor_proto: TensorProto) -> np.ndarray:
     dtype = DataType(tensor_proto.dtype)
     shape = extract_shape(tensor_proto)
+    # MIIL extension: this is needed to deal with the format returned by OpenVino inference server.
+    if tensor_proto.tensor_content:
+        return (np.frombuffer(tensor_proto.tensor_content,
+                              dtype=dtype.numpy_dtype).copy().reshape(shape))
+    # Remark: Looks like we will never reach those lines in the case of OVMS
+    # Important: in the original implementation of tensorflow_serving, there is support to handle other formats
+    # of tensor_proto, such as float16, float32 etc.
+    # It seems in our case we don't need to handle those cases since OVMS will not return those types.
     proto_values = getattr(tensor_proto, dtype.proto_field_name)
     return np.array([element for element in proto_values], dtype=dtype.numpy_dtype).reshape(*shape)


### PR DESCRIPTION
The following PR adds support for gRPC inference requests with OpenVino model server.